### PR TITLE
[14] - Cambio de token en topsofthetops

### DIFF
--- a/app/Services/Top_games.php
+++ b/app/Services/Top_games.php
@@ -11,8 +11,8 @@ class Top_games
     {
 
         // Parámetros de la API de Twitch
-        $client_id = '8sjfuizn8p9ee61m0rpd5rxg1kopfg';
-        $token = 'z859ot3xmyincj3uyf2wf62kfc5958';
+        $client_id = 'ry2x90s1y7srrwh89y6twcxfz0gi8u';
+        $token = 's1q53moenjf7gigkq4lhkvw9mvfkmo';
 
         // URL de la API de Twitch para obtener el top de juegos, incluyendo el parámetro 'first' para limitar a 3 juegos
         $url = 'https://api.twitch.tv/helix/games/top?first=3';

--- a/app/Services/Top_videos.php
+++ b/app/Services/Top_videos.php
@@ -10,8 +10,8 @@ class Top_videos
     public static function updateTopVideos($gameId)
     {
         // Parámetros de la API de Twitch
-        $client_id = '8sjfuizn8p9ee61m0rpd5rxg1kopfg';
-        $token = 'z859ot3xmyincj3uyf2wf62kfc5958';
+        $client_id = 'ry2x90s1y7srrwh89y6twcxfz0gi8u';
+        $token = 's1q53moenjf7gigkq4lhkvw9mvfkmo';
 
         // URL de la API de Twitch para obtener los videos de un juego específico
         $videos_url = 'https://api.twitch.tv/helix/videos';


### PR DESCRIPTION
### Actualización token en topsofthetops
He actulizado el token en Top_games.php y en Top_videos.php que es donde se hacen llamadas a la API, este cambio se debe a que aparentemente topsofthetops había dejado de funcionar y el problema era que el token estaba caducado. Aún así falta implementar la parte de la base de datos en dichos archivos para que se coja automáticamente el token de allí.