### PR TITLE
[107] - Logica follow streamer provider

### DIFF
--- a/app/Config/JsonReturnMessages.php
+++ b/app/Config/JsonReturnMessages.php
@@ -11,9 +11,11 @@ class JsonReturnMessages
 
     public const USER_LIST_SERVER_ERROR_500 = 'Error del servidor al obtener la lista de usuarios.';
 
-    public const FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_401 = ' Token de autenticación no proporcionado o inválido';
+    public const FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_400 = 'Usuario o Streamer no proporcionado';
+    public const FOLLOW_STREAMER_UNAUTHORIZED_401                 = 'Token de autenticación no proporcionado o inválido';
     public const FOLLOW_STREAMER_FORBIDDEN                        = 'Acceso denegado debido a permisos insuficientes';
     public const FOLLOW_STREAMER_NOT_FOUND_404                    = 'El usuario ( userId ) o el streamer ( streamerId ) especificado no existe en la API';
     public const FOLLOW_STREAMERS_CONFLICT_409                    = 'El usuario ya está siguiendo al streamer';
     public const FOLLOW_STREAMERS_SERVER_ERROR_500                = 'Error del servidor al seguir al streamer';
+    public const FOLLOW_STREAMER_SUCCESFUL_RESPONSE_200           = 'Ahora sigues a streamerId';
 }

--- a/app/Config/JsonReturnMessages.php
+++ b/app/Config/JsonReturnMessages.php
@@ -12,8 +12,8 @@ class JsonReturnMessages
     public const USER_LIST_SERVER_ERROR_500 = 'Error del servidor al obtener la lista de usuarios.';
 
     public const FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_401 = ' Token de autenticación no proporcionado o inválido';
-    public const FOLLOW_STREAMER_FORBIDDEN = 'Acceso denegado debido a permisos insuficientes';
-    public const FOLLOW_STREAMER_NOT_FOUND_404 = 'El usuario ( userId ) o el streamer ( streamerId ) especificado no existe en la API';
-    public const FOLLOW_STREAMERS_CONFLICT_409 = 'El usuario ya está siguiendo al streamer';
-    public const FOLLOW_STREAMERS_SERVER_ERROR_500 = 'Error del servidor al seguir al streamer';
+    public const FOLLOW_STREAMER_FORBIDDEN                        = 'Acceso denegado debido a permisos insuficientes';
+    public const FOLLOW_STREAMER_NOT_FOUND_404                    = 'El usuario ( userId ) o el streamer ( streamerId ) especificado no existe en la API';
+    public const FOLLOW_STREAMERS_CONFLICT_409                    = 'El usuario ya está siguiendo al streamer';
+    public const FOLLOW_STREAMERS_SERVER_ERROR_500                = 'Error del servidor al seguir al streamer';
 }

--- a/app/Config/JsonReturnMessages.php
+++ b/app/Config/JsonReturnMessages.php
@@ -10,4 +10,10 @@ class JsonReturnMessages
     public const NEW_USER_SUCCESSFUL_RESPONSE_201 = 'Usuario creado correctamente';
 
     public const USER_LIST_SERVER_ERROR_500 = 'Error del servidor al obtener la lista de usuarios.';
+
+    public const FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_401 = ' Token de autenticación no proporcionado o inválido';
+    public const FOLLOW_STREAMER_FORBIDDEN = 'Acceso denegado debido a permisos insuficientes';
+    public const FOLLOW_STREAMER_NOT_FOUND_404 = 'El usuario ( userId ) o el streamer ( streamerId ) especificado no existe en la API';
+    public const FOLLOW_STREAMERS_CONFLICT_409 = 'El usuario ya está siguiendo al streamer';
+    public const FOLLOW_STREAMERS_SERVER_ERROR_500 = 'Error del servidor al seguir al streamer';
 }

--- a/app/Infrastructure/Clients/DBClient.php
+++ b/app/Infrastructure/Clients/DBClient.php
@@ -83,4 +83,11 @@ class DBClient
             })
             ->exists();
     }
+
+    public function followStreamer(int $userId, int $streamerId): void
+    {
+        $user = TwitchUser::findOrFail($userId);
+        $user->streamers()->attach($streamerId);
+    }
+
 }

--- a/app/Infrastructure/Clients/DBClient.php
+++ b/app/Infrastructure/Clients/DBClient.php
@@ -74,4 +74,13 @@ class DBClient
             ];
         })->toArray();
     }
+
+    public function doesUserFollowStreamer(int $userId, int $streamerId): bool
+    {
+        return TwitchUser::where('user_id', $userId)
+            ->whereHas('streamers', function ($query) use ($streamerId) {
+                $query->where('streamer_id', $streamerId);
+            })
+            ->exists();
+    }
 }

--- a/app/Infrastructure/Controllers/FollowStreamerController.php
+++ b/app/Infrastructure/Controllers/FollowStreamerController.php
@@ -21,7 +21,7 @@ class FollowStreamerController
         $user_id     = $request->input('userId');
         $streamer_id = $request->input('streamerId');
 
-        if(empty($user_id) || empty($streamer_id)) {
+        if (empty($user_id) || empty($streamer_id) || !is_numeric($user_id) || !is_numeric($streamer_id)) {
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_400], 400);
         }
 

--- a/app/Infrastructure/Controllers/FollowStreamerController.php
+++ b/app/Infrastructure/Controllers/FollowStreamerController.php
@@ -25,6 +25,6 @@ class FollowStreamerController
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_400], 400);
         }
 
-        return $this->followProvider->execute($user_id, $streamer_id);
+        return $this->followProvider->execute((int) $user_id, (int) $streamer_id);
     }
 }

--- a/app/Infrastructure/Controllers/FollowStreamerController.php
+++ b/app/Infrastructure/Controllers/FollowStreamerController.php
@@ -9,12 +9,13 @@ use Illuminate\Http\Request;
 
 class FollowStreamerController
 {
-    private $followProvider;
+    private FollowStreamersProvider $followProvider;
 
-    public function __construct($followProvider)
+    public function __construct(FollowStreamersProvider $followProvider)
     {
         $this->followProvider = $followProvider;
     }
+
     public function __invoke(Request $request): JsonResponse
     {
         $user_id     = $request->input('userId');
@@ -24,6 +25,6 @@ class FollowStreamerController
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_400], 400);
         }
 
-        return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500]);
+        return $this->followProvider->execute($user_id, $streamer_id);
     }
 }

--- a/app/Infrastructure/Controllers/FollowStreamerController.php
+++ b/app/Infrastructure/Controllers/FollowStreamerController.php
@@ -2,11 +2,28 @@
 
 namespace App\Infrastructure\Controllers;
 
+use App\Config\JsonReturnMessages;
+use App\Services\UsersDataManager\FollowStreamersProvider;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class FollowStreamerController
 {
-    public function __invoke(Request $request)
+    private $followProvider;
+
+    public function __construct($followProvider)
     {
+        $this->followProvider = $followProvider;
+    }
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user_id     = $request->input('userId');
+        $streamer_id = $request->input('streamerId');
+
+        if(empty($user_id) || empty($streamer_id)) {
+            return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_400], 400);
+        }
+
+        return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500]);
     }
 }

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -21,4 +21,8 @@ class Token extends Model
     protected $fillable = ['token'];  // Los atributos que se pueden asignar masivamente
 
     protected $dates = ['created_at'];  // Trata 'created_at' como una instancia de Carbon
+
+    public static function latest(string $string)
+    {
+    }
 }

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -34,9 +34,16 @@ class FollowStreamersProvider
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404], 404);
         }
 
-        $accessToken = $this->tokenProvider->getToken();
-        $clientId    = $this->twitchConfig->clientId();
+        try {
+            $accessToken = $this->tokenProvider->getToken();
+        } catch (Exception $e) {
+            if ($e->getCode() === 401) {
+                return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_UNAUTHORIZED_401], 401);
+            }
+            throw $e;
+        }
 
+        $clientId = $this->twitchConfig->clientId();
         $response = $this->apiClient->getDataForStreamersFromAPI($clientId, $accessToken, $streamerId);
 
         if (!$response->successful() || empty($response->json()['data'])) {

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -43,6 +43,10 @@ class FollowStreamersProvider
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404], 404);
         }
 
+        if ($this->dbClient->doesUserFollowStreamer($userId, $streamerId)) {
+            return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMERS_CONFLICT_409], 409);
+        }
+
         return response()->json(['Internal Server Error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500], 500);
     }
 }

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -8,13 +8,15 @@ use Illuminate\Http\JsonResponse;
 
 class FollowStreamersProvider
 {
+    private DBClient $dbClient;
+
     public function __construct(DBClient $dbClient)
     {
+        $this->dbClient = $dbClient;
     }
 
-    public function execute(): JsonResponse
+    public function execute(int $userId, int $streamerId): JsonResponse
     {
         return response()->json(['Internal Server Error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500], 500);
     }
-
 }

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -17,6 +17,10 @@ class FollowStreamersProvider
 
     public function execute(int $userId, int $streamerId): JsonResponse
     {
+        if (!$this->dbClient->doesTwitchUserExist($userId)) {
+            return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404], 404);
+        }
+
         return response()->json(['Internal Server Error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500], 500);
     }
 }

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services\UsersDataManager;
+
+use App\Config\JsonReturnMessages;
+use App\Infrastructure\Clients\DBClient;
+use Illuminate\Http\JsonResponse;
+
+class FollowStreamersProvider
+{
+    public function __construct(DBClient $dbClient)
+    {
+    }
+
+    public function execute(): JsonResponse
+    {
+        return response()->json(['Internal Server Error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500], 500);
+    }
+
+}

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -3,21 +3,43 @@
 namespace App\Services\UsersDataManager;
 
 use App\Config\JsonReturnMessages;
+use App\Config\TwitchConfig;
+use App\Infrastructure\Clients\APIClient;
 use App\Infrastructure\Clients\DBClient;
+use App\Services\TokenProvider;
+use Exception;
 use Illuminate\Http\JsonResponse;
 
 class FollowStreamersProvider
 {
     private DBClient $dbClient;
+    private APIClient $apiClient;
+    private TokenProvider $tokenProvider;
+    private TwitchConfig $twitchConfig;
 
-    public function __construct(DBClient $dbClient)
+    public function __construct(DBClient $dbClient, APIClient $apiClient, TokenProvider $tokenProvider, TwitchConfig $twitchConfig)
     {
-        $this->dbClient = $dbClient;
+        $this->dbClient      = $dbClient;
+        $this->apiClient     = $apiClient;
+        $this->tokenProvider = $tokenProvider;
+        $this->twitchConfig  = $twitchConfig;
     }
 
+    /**
+     * @throws Exception
+     */
     public function execute(int $userId, int $streamerId): JsonResponse
     {
         if (!$this->dbClient->doesTwitchUserExist($userId)) {
+            return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404], 404);
+        }
+
+        $accessToken = $this->tokenProvider->getToken();
+        $clientId    = $this->twitchConfig->clientId();
+
+        $response = $this->apiClient->getDataForStreamersFromAPI($clientId, $accessToken, $streamerId);
+
+        if (!$response->successful() || empty($response->json()['data'])) {
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404], 404);
         }
 

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -43,10 +43,6 @@ class FollowStreamersProvider
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404], 404);
         }
 
-        if ($this->dbClient->doesUserFollowStreamer($userId, $streamerId)) {
-            return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMERS_CONFLICT_409], 409);
-        }
-
         return response()->json(['Internal Server Error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500], 500);
     }
 }

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -46,7 +46,7 @@ class FollowStreamersProvider
         $clientId = $this->twitchConfig->clientId();
         try {
             $response = $this->apiClient->getDataForStreamersFromAPI($clientId, $accessToken, $streamerId);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500], 500);
         }
 

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -58,6 +58,8 @@ class FollowStreamersProvider
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMERS_CONFLICT_409], 409);
         }
 
-        return response()->json(['Internal Server Error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500], 500);
+        $this->dbClient->followStreamer($userId, $streamerId);
+
+        return response()->json(['message' => JsonReturnMessages::FOLLOW_STREAMER_SUCCESFUL_RESPONSE_200], 200);
     }
 }

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -50,6 +50,10 @@ class FollowStreamersProvider
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404], 404);
         }
 
+        if ($this->dbClient->doesUserFollowStreamer($userId, $streamerId)) {
+            return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMERS_CONFLICT_409], 409);
+        }
+
         return response()->json(['Internal Server Error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500], 500);
     }
 }

--- a/app/Services/UsersDataManager/FollowStreamersProvider.php
+++ b/app/Services/UsersDataManager/FollowStreamersProvider.php
@@ -44,7 +44,11 @@ class FollowStreamersProvider
         }
 
         $clientId = $this->twitchConfig->clientId();
-        $response = $this->apiClient->getDataForStreamersFromAPI($clientId, $accessToken, $streamerId);
+        try {
+            $response = $this->apiClient->getDataForStreamersFromAPI($clientId, $accessToken, $streamerId);
+        } catch (Exception $e) {
+            return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500], 500);
+        }
 
         if (!$response->successful() || empty($response->json()['data'])) {
             return response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404], 404);

--- a/tests/Unit/Infrastructure/Controllers/FollowStreamerControllerTest.php
+++ b/tests/Unit/Infrastructure/Controllers/FollowStreamerControllerTest.php
@@ -8,11 +8,12 @@ use App\Services\UsersDataManager\FollowStreamersProvider;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Mockery;
+use Mockery\MockInterface;
 use Tests\TestCase;
 
 class FollowStreamerControllerTest extends TestCase
 {
-    protected FollowStreamersProvider|(Mockery\MockInterface&Mockery\LegacyMockInterface) $followProvider;
+    protected MockInterface $followProvider;
     protected FollowStreamerController $followController;
 
     protected function setUp(): void

--- a/tests/Unit/Infrastructure/Controllers/FollowStreamerControllerTest.php
+++ b/tests/Unit/Infrastructure/Controllers/FollowStreamerControllerTest.php
@@ -11,6 +11,9 @@ use Mockery;
 use Mockery\MockInterface;
 use Tests\TestCase;
 
+/**
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
 class FollowStreamerControllerTest extends TestCase
 {
     protected MockInterface $followProvider;

--- a/tests/Unit/Infrastructure/Controllers/FollowStreamerControllerTest.php
+++ b/tests/Unit/Infrastructure/Controllers/FollowStreamerControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Infrastructure\Controllers;
+
+use App\Config\JsonReturnMessages;
+use App\Infrastructure\Controllers\FollowStreamerController;
+use App\Services\UsersDataManager\FollowStreamersProvider;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Mockery;
+use Tests\TestCase;
+
+class FollowStreamerControllerTest extends TestCase
+{
+    protected FollowStreamersProvider|(Mockery\MockInterface&Mockery\LegacyMockInterface) $followProvider;
+    protected FollowStreamerController $followController;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->followProvider   = Mockery::mock(FollowStreamersProvider::class);
+        $this->followController = new FollowStreamerController($this->followProvider);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function not_given_userId_returns_error_400()
+    {
+        $request = new Request(['streamerId' => 'streamerId']);
+
+        $response = $this->followController->__invoke($request);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(JsonReturnMessages::FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_400, $response->getData()->error);
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function not_given_streamerId_returns_error_400()
+    {
+        $request = new Request(['userId' => 'usuarioId']);
+
+        $response = $this->followController->__invoke($request);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(JsonReturnMessages::FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_400, $response->getData()->error);
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+}

--- a/tests/Unit/Infrastructure/Controllers/FollowStreamerControllerTest.php
+++ b/tests/Unit/Infrastructure/Controllers/FollowStreamerControllerTest.php
@@ -60,4 +60,27 @@ class FollowStreamerControllerTest extends TestCase
         $this->assertEquals(JsonReturnMessages::FOLLOW_STREAMER_PARAMETER_MISSING_OR_INVALID_400, $response->getData()->error);
         $this->assertEquals(400, $response->getStatusCode());
     }
+
+    /**
+     * @test
+     */
+    public function given_nonexistent_userId_returns_error_404()
+    {
+        // Arrange
+        $request = Request::create('/analytics/follow', 'POST', ['userId' => '999', 'streamerId' => '1']);
+
+        $this->followProvider
+            ->shouldReceive('execute')
+            ->once()
+            ->withArgs([999, 1])
+            ->andReturn(response()->json(['error' => JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404], 404));
+
+        // Act
+        $response = $this->followController->__invoke($request);
+
+        // Assert
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404, $response->getData()->error);
+        $this->assertEquals(404, $response->getStatusCode());
+    }
 }

--- a/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
+++ b/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
@@ -165,6 +165,7 @@ class FollowStreamersProviderTest extends TestCase
 
     /**
      * @test
+     * @throws Exception
      */
     public function given_server_error_returns_error_500()
     {

--- a/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
+++ b/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
@@ -3,9 +3,13 @@
 namespace Services\UsersDataManager;
 
 use App\Config\JsonReturnMessages;
+use App\Infrastructure\Clients\APIClient;
 use App\Infrastructure\Clients\DBClient;
+use App\Services\TokenProvider;
 use App\Services\UsersDataManager\FollowStreamersProvider;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use Mockery;
 use Mockery\MockInterface;
 use Tests\TestCase;
@@ -16,6 +20,8 @@ use Tests\TestCase;
 class FollowStreamersProviderTest extends TestCase
 {
     protected MockInterface $dbClient;
+    protected MockInterface $apiClient;
+    protected MockInterface $tokenProvider;
     protected FollowStreamersProvider $followProvider;
 
     protected function setUp(): void
@@ -23,7 +29,9 @@ class FollowStreamersProviderTest extends TestCase
         parent::setUp();
 
         $this->dbClient       = Mockery::mock(DBClient::class);
-        $this->followProvider = new FollowStreamersProvider($this->dbClient);
+        $this->apiClient      = Mockery::mock(APIClient::class);
+        $this->tokenProvider  = Mockery::mock(TokenProvider::class);
+        $this->followProvider = new FollowStreamersProvider($this->dbClient, $this->apiClient, $this->tokenProvider);
     }
 
     protected function tearDown(): void
@@ -44,6 +52,33 @@ class FollowStreamersProviderTest extends TestCase
             ->andReturn(false);
 
         $response = $this->followProvider->execute(999, 1);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404, $response->getData()->error);
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function given_a_streamerId_not_found_returns_error_404()
+    {
+        $this->dbClient
+            ->shouldReceive('doesTwitchUserExist')
+            ->once()
+            ->with(1)
+            ->andReturn(true);
+        $this->tokenProvider
+            ->shouldReceive('getToken')
+            ->once()
+            ->andReturn('fake_access_token');
+        $this->apiClient
+            ->shouldReceive('getDataForStreamersFromAPI')
+            ->once()
+            ->with('fake_client_id', 'fake_access_token', 999)
+            ->andReturn(new Response(new GuzzleResponse(200, [], json_encode(['data' => []]))));
+
+        $response = $this->followProvider->execute(1, 999);
 
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals(JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404, $response->getData()->error);

--- a/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
+++ b/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
@@ -38,7 +38,7 @@ class FollowStreamersProviderTest extends TestCase
     public function given_a_userId_not_found_returns_error_404()
     {
         $this->dbClient
-            ->shouldReceive('doesUserExist')
+            ->shouldReceive('doesTwitchUserExist')
             ->once()
             ->with(999)
             ->andReturn(false);

--- a/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
+++ b/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
@@ -6,11 +6,10 @@ use App\Config\JsonReturnMessages;
 use App\Config\TwitchConfig;
 use App\Infrastructure\Clients\APIClient;
 use App\Infrastructure\Clients\DBClient;
-use App\Services\StreamsDataManager\StreamsDataProvider;
 use App\Services\TokenProvider;
 use App\Services\UsersDataManager\FollowStreamersProvider;
 use Exception;
-use GuzzleHttp\Psr7\Response as GuzzleResponse; // Use alias to avoid conflict
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Client\Response as HttpResponse;
 use Mockery;
@@ -27,18 +26,16 @@ class FollowStreamersProviderTest extends TestCase
     protected MockInterface $tokenProvider;
     protected MockInterface $twitchConfig;
     protected FollowStreamersProvider $followProvider;
-    protected StreamsDataProvider $streamsProvider;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->dbClient        = Mockery::mock(DBClient::class);
-        $this->apiClient       = Mockery::mock(APIClient::class);
-        $this->tokenProvider   = Mockery::mock(TokenProvider::class);
-        $this->twitchConfig    = Mockery::mock(TwitchConfig::class);
-        $this->followProvider  = new FollowStreamersProvider($this->dbClient, $this->apiClient, $this->tokenProvider, $this->twitchConfig);
-        $this->streamsProvider = new StreamsDataProvider($this->tokenProvider, $this->apiClient, $this->twitchConfig);
+        $this->dbClient       = Mockery::mock(DBClient::class);
+        $this->apiClient      = Mockery::mock(APIClient::class);
+        $this->tokenProvider  = Mockery::mock(TokenProvider::class);
+        $this->twitchConfig   = Mockery::mock(TwitchConfig::class);
+        $this->followProvider = new FollowStreamersProvider($this->dbClient, $this->apiClient, $this->tokenProvider, $this->twitchConfig);
     }
 
     protected function tearDown(): void
@@ -86,7 +83,8 @@ class FollowStreamersProviderTest extends TestCase
             ->once()
             ->andReturn('fake_client_id');
 
-        $response = new HttpResponse(new GuzzleResponse(200, [], json_encode(['data' => []])));
+        $guzzleResponse = new GuzzleResponse(200, [], json_encode(['data' => []]));
+        $response       = new HttpResponse($guzzleResponse);
         $this->apiClient
             ->expects('getDataForStreamersFromAPI')
             ->once()
@@ -120,7 +118,8 @@ class FollowStreamersProviderTest extends TestCase
             ->once()
             ->andReturn('fake_client_id');
 
-        $response = new HttpResponse(new GuzzleResponse(200, [], json_encode(['data' => [['id' => '999', 'login' => 'teststreamer']]])));
+        $guzzleResponse = new GuzzleResponse(200, [], json_encode(['data' => [['id' => '999', 'login' => 'teststreamer']]]));
+        $response       = new HttpResponse($guzzleResponse);
         $this->apiClient
             ->expects('getDataForStreamersFromAPI')
             ->once()
@@ -193,5 +192,50 @@ class FollowStreamersProviderTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals(JsonReturnMessages::FOLLOW_STREAMERS_SERVER_ERROR_500, $response->getData()->error);
         $this->assertEquals(500, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     * @throws Exception
+     */
+    public function given_valid_user_and_streamer_returns_success_200()
+    {
+        $this->dbClient
+            ->expects('doesTwitchUserExist')
+            ->once()
+            ->with(1)
+            ->andReturn(true);
+        $this->tokenProvider
+            ->expects('getToken')
+            ->once()
+            ->andReturn('fake_access_token');
+        $this->twitchConfig
+            ->expects('clientId')
+            ->once()
+            ->andReturn('fake_client_id');
+
+        $guzzleResponse = new GuzzleResponse(200, [], json_encode(['data' => [['id' => '999', 'login' => 'teststreamer']]]));
+        $response       = new HttpResponse($guzzleResponse);
+        $this->apiClient
+            ->expects('getDataForStreamersFromAPI')
+            ->once()
+            ->with('fake_client_id', 'fake_access_token', 999)
+            ->andReturn($response);
+
+        $this->dbClient
+            ->expects('doesUserFollowStreamer')
+            ->once()
+            ->with(1, 999)
+            ->andReturn(false);
+        $this->dbClient
+            ->expects('followStreamer')
+            ->once()
+            ->with(1, 999);
+
+        $response = $this->followProvider->execute(1, 999);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(['message' => JsonReturnMessages::FOLLOW_STREAMER_SUCCESFUL_RESPONSE_200], $response->getData(true));
+        $this->assertEquals(200, $response->getStatusCode());
     }
 }

--- a/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
+++ b/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Services\UsersDataManager;
+
+use App\Config\JsonReturnMessages;
+use App\Infrastructure\Clients\DBClient;
+use App\Services\UsersDataManager\FollowStreamersProvider;
+use Illuminate\Http\JsonResponse;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+/**
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+class FollowStreamersProviderTest extends TestCase
+{
+    protected MockInterface $dbClient;
+    protected FollowStreamersProvider $followProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dbClient       = Mockery::mock(DBClient::class);
+        $this->followProvider = new FollowStreamersProvider($this->dbClient);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function given_a_userId_notFounded_returns_error_404()
+    {
+        // Arrange
+        $this->dbClient
+            ->shouldReceive('doesUserExist')
+            ->once()
+            ->with(999)
+            ->andReturn(false);
+
+        // Act
+        $response = $this->followProvider->execute(999, 1);
+
+        // Assert
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404, $response->getData()->error);
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+}

--- a/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
+++ b/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
@@ -150,10 +150,11 @@ class FollowStreamersProviderTest extends TestCase
             ->once()
             ->with(1)
             ->andReturn(true);
+
         $this->tokenProvider
             ->expects('getToken')
             ->once()
-            ->andReturn(null);
+            ->andThrow(new Exception('Unauthorized', 401));
 
         $response = $this->followProvider->execute(1, 999);
 

--- a/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
+++ b/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
@@ -35,19 +35,16 @@ class FollowStreamersProviderTest extends TestCase
     /**
      * @test
      */
-    public function given_a_userId_notFounded_returns_error_404()
+    public function given_a_userId_not_found_returns_error_404()
     {
-        // Arrange
         $this->dbClient
             ->shouldReceive('doesUserExist')
             ->once()
             ->with(999)
             ->andReturn(false);
 
-        // Act
         $response = $this->followProvider->execute(999, 1);
 
-        // Assert
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals(JsonReturnMessages::FOLLOW_STREAMER_NOT_FOUND_404, $response->getData()->error);
         $this->assertEquals(404, $response->getStatusCode());

--- a/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
+++ b/tests/Unit/Services/UsersDataManager/FollowStreamersProviderTest.php
@@ -8,9 +8,10 @@ use App\Infrastructure\Clients\APIClient;
 use App\Infrastructure\Clients\DBClient;
 use App\Services\TokenProvider;
 use App\Services\UsersDataManager\FollowStreamersProvider;
+use Exception;
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Client\Response;
-use GuzzleHttp\Psr7\Response as GuzzleResponse; // Importar la clase correcta para Guzzle Response
+use Illuminate\Http\Client\Response as HttpResponse;
 use Mockery;
 use Mockery\MockInterface;
 use Tests\TestCase;
@@ -45,12 +46,12 @@ class FollowStreamersProviderTest extends TestCase
 
     /**
      * @test
-     * @throws \Exception
+     * @throws Exception
      */
     public function given_a_userId_not_found_returns_error_404()
     {
         $this->dbClient
-            ->shouldReceive('doesTwitchUserExist')
+            ->expects('doesTwitchUserExist')
             ->once()
             ->with(999)
             ->andReturn(false);
@@ -64,27 +65,28 @@ class FollowStreamersProviderTest extends TestCase
 
     /**
      * @test
+     * @throws Exception
      */
     public function given_a_streamerId_not_found_returns_error_404()
     {
         $this->dbClient
-            ->shouldReceive('doesTwitchUserExist')
+            ->expects('doesTwitchUserExist')
             ->once()
             ->with(1)
             ->andReturn(true);
         $this->tokenProvider
-            ->shouldReceive('getToken')
+            ->expects('getToken')
             ->once()
             ->andReturn('fake_access_token');
         $this->twitchConfig
-            ->shouldReceive('clientId')
+            ->expects('clientId')
             ->once()
             ->andReturn('fake_client_id');
 
-        $response = new Response(new GuzzleResponse(200, [], json_encode(['data' => []])));
+        $response = new HttpResponse(new Response(200, [], json_encode(['data' => []])));
 
         $this->apiClient
-            ->shouldReceive('getDataForStreamersFromAPI')
+            ->expects('getDataForStreamersFromAPI')
             ->once()
             ->with('fake_client_id', 'fake_access_token', 999)
             ->andReturn($response);


### PR DESCRIPTION
Toda la logica correspondiente a seguir a un usuario manejando los siguientes errores:

- 400 Missing parameters
- 401 Unauthorized : Token de autenticación no proporcionado o inválido.
- 404 Not Found : El usuario ( userId ) o el streamer ( streamerId ) especificado no existe en la API.
- 409 Conflict : El usuario ya está siguiendo al streamer.
- 500 Internal Server Error : Error del servidor al seguir al streamer.
